### PR TITLE
Update Port to Avoid Airplay Receiver conflict on macOS

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: docker/Dockerfile
     container_name: sentient-backend
     ports:
-      - "5000:5000"
+      - "5001:5000" # Changed from 5000 to 5001 to avoid port conflict due airplay receiver on macOS
     environment:
       - PYTHONUNBUFFERED=1
       - SENTIENT_CONFIG_PATH=/app/sentient.yaml
@@ -39,7 +39,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - VITE_API_URL=http://localhost:5000
+      - VITE_API_URL=http://localhost:5001
       - DOCKER_ENV=true
     volumes:
       - ../frontend/src:/app/src:ro


### PR DESCRIPTION
Changes Made:

- Changed default Port number in `docker-compose.yml` backend service from `5000:5000` to `5001:5000` to avoid airplay receiver port conflict on macOS.  

Benefits:

-  Airplay receiver uses port `5000` by default and such completely terminates the docker setup from completing. Changing the port value promptly solved this issue
 