### PR TITLE
Fixed failures on complex deep research tasks

### DIFF
--- a/src/sentientresearchagent/hierarchical_agent_framework/node/node_creation_utils.py
+++ b/src/sentientresearchagent/hierarchical_agent_framework/node/node_creation_utils.py
@@ -23,6 +23,14 @@ class SubNodeCreator:
         """
         if not parent_node.sub_graph_id:
             parent_node.sub_graph_id = f"subgraph_{parent_node.task_id}"
+
+            # If a stale graph somehow exists (e.g., after partial recovery), remove it first
+            if self.task_graph.get_graph(parent_node.sub_graph_id):
+                logger.warning(
+                    f"    SubNodeCreator: Found existing graph '{parent_node.sub_graph_id}' before creation. Removing stale graph to avoid ID collisions."
+                )
+                self.task_graph.remove_graph_and_nodes(parent_node.sub_graph_id, self.knowledge_store)
+
             self.task_graph.add_graph(parent_node.sub_graph_id)
             logger.info(f"    SubNodeCreator: Created new subgraph '{parent_node.sub_graph_id}' for parent '{parent_node.task_id}'")
             # CRITICAL: Update parent node in knowledge store after setting sub_graph_id

--- a/src/sentientresearchagent/hierarchical_agent_framework/orchestration/recovery_manager.py
+++ b/src/sentientresearchagent/hierarchical_agent_framework/orchestration/recovery_manager.py
@@ -377,13 +377,13 @@ class DeadlockRecoveryStrategy:
         node = task_graph.get_node(node_id)
         
         if node and node.status == TaskStatus.RUNNING:
-            # Force replan
             logger.warning(f"Forcing replan for hanging node {node_id}")
-            node.update_status(
-                TaskStatus.NEEDS_REPLAN,
-                error_msg="Node hanging in RUNNING state"
-            )
-            
+
+            # Do not pass error_msg directly to avoid the status being coerced to FAILED
+            node.replan_reason = "Recovered from single-node hang"
+            node.update_status(TaskStatus.NEEDS_REPLAN)
+            node.error = "Node hanging in RUNNING state"
+
             return {
                 "recovered": True,
                 "action": f"Forced hanging node {node_id} to NEEDS_REPLAN"


### PR DESCRIPTION
 - Extended goal-length handling to 10 000 chars end-to-end so DeepResearch prompts stop rejecting valid input (fastapi_server.py:104, src/sentientresearchagent/server/utils/validation.py:60).
  - Propagated the reduced single-node hang timeout through config defaults, serialization, and DeadlockDetector wiring to catch stuck nodes sooner (src/sentientresearchagent/config/config.py:90, :170, :213, src/sentientresearchagent/core/system_manager.py:130).
  - Cleaned GPT‑5 usage: AgentFactory now strips unsupported params, YAML configs drop temperature, and the scheduler surfaces NEEDS_REPLAN work items so replans actually fire (src/sentientresearchagent/hierarchical_agent_framework/agent_configs/agent_factory.py:218,
  agents.yaml:32, src/sentientresearchagent/hierarchical_agent_framework/orchestration/task_scheduler.py:73).
  - Fixed the “subgraph already exists” deadlock by adding graph/record teardown helpers and calling them from the Replan handler (src/sentientresearchagent/hierarchical_agent_framework/context/knowledge_store.py:90, graph/task_graph.py:122, node_handlers/
  replan_handler.py:264).
  - Trimmed redundant trace chatter and aligned tooling/infra defaults (.python-version:1, tracing/models.py:134).

  Validation

  - ./setup.sh --docker-from-scratch
  
<img width="1916" height="1010" alt="Screenshot 2025-09-30 at 23 02 14" src="https://github.com/user-attachments/assets/5b81f425-599c-4830-8a7c-cc9d3d8d0d27" />

  
### Download report: [project-report.md](https://github.com/user-attachments/files/22626355/project-report.md)

  