### PR TITLE
fix: correct malformed AgnoAgents link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Choose between:
 
 ## 🛠️ Technical Stack
 
-- **Framework**: Built on [AgnoAgents]([https://github.com/your/agnoagents](https://github.com/agno-agi/agno))
+- **Framework**: Built on [AgnoAgents](https://github.com/agno-agi/agno)
 - **Backend**: Python 3.12+ with FastAPI/Flask
 - **Frontend**: React + TypeScript with real-time WebSocket
 - **LLM Support**: Any provider via LiteLLM


### PR DESCRIPTION
- Fix broken markdown link format on line 149
- Change `[AgnoAgents]([url1](url2))` to proper format `[AgnoAgents](url)`
- Ensure AgnoAgents link is clickable in rendered markdown

This fixes the link formatting issue that was preventing the AgnoAgents framework link from working properly in the documentation.