### PR TITLE
Allow user to configure stuck duration (Infinite Loop)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -183,6 +183,7 @@ execution:
   max_execution_steps: 500      # Maximum total steps
   max_recursion_depth: 5        # Maximum task depth
   node_execution_timeout_seconds: 2400.0  # 40 minutes
+  max_stuck_duration: 300  # 5 minutes
   
   # Rate Limiting
   rate_limit_rpm: 30            # Requests per minute

--- a/sentient.yaml
+++ b/sentient.yaml
@@ -25,6 +25,7 @@ execution:
   enable_hitl: false
   hitl_timeout_seconds: 1200.0  # 10 minutes for human review
   node_execution_timeout_seconds: 2400.0  # 40 minutes max for overall task execution
+  max_stuck_duration: 300  # 5 minutes waiting for all stucked tasks
   
   # New: State management optimization
   state_batch_size: 50      # Batch size for state updates

--- a/src/sentientresearchagent/config/config.py
+++ b/src/sentientresearchagent/config/config.py
@@ -87,6 +87,7 @@ class ExecutionConfig(BaseModel):
     max_execution_steps: int = 500  # Updated to match YAML default
     max_recursion_depth: int = 5  # NEW: Maximum recursion depth for task decomposition
     node_execution_timeout_seconds: float = 2400.0  # Updated to match YAML default (40 minutes)
+    max_stuck_duration: int = 300  # Get out from Infinite Loops (in 5 minutes) 
     
     # State management optimization
     state_batch_size: int = 50      # Batch size for state updates
@@ -165,6 +166,7 @@ class ExecutionConfig(BaseModel):
                 'max_execution_steps': 500,
                 'max_recursion_depth': 5,
                 'node_execution_timeout_seconds': 2400.0,
+                'max_stuck_duration': 300,
                 'state_batch_size': 50,
                 'state_batch_timeout_ms': 100,
                 'enable_state_compression': True,
@@ -209,6 +211,7 @@ class ExecutionConfig(BaseModel):
             'max_execution_steps': self.max_execution_steps,
             'max_recursion_depth': self.max_recursion_depth,
             'node_execution_timeout_seconds': self.node_execution_timeout_seconds,
+            'max_stuck_duration': self.max_stuck_duration,
             'rate_limit_rpm': self.rate_limit_rpm,
             'state_batch_size': self.state_batch_size,
             'state_batch_timeout_ms': self.state_batch_timeout_ms,
@@ -468,6 +471,7 @@ class SentientConfig(BaseModel):
             f"{prefix}MAX_CONCURRENT": ("execution", "max_concurrent_nodes"),
             f"{prefix}MAX_STEPS": ("execution", "max_execution_steps"),
             f"{prefix}EXECUTION_TIMEOUT": ("execution", "node_execution_timeout_seconds"),
+            f"{prefix}STUCK_DURATION": ("execution", "max_stuck_duration"),
             f"{prefix}HITL_TIMEOUT": ("execution", "hitl_timeout_seconds"),
             f"{prefix}ENABLE_HITL": ("execution", "enable_hitl"),
             f"{prefix}LOG_LEVEL": ("logging", "level"),

--- a/src/sentientresearchagent/hierarchical_agent_framework/orchestration/execution_orchestrator.py
+++ b/src/sentientresearchagent/hierarchical_agent_framework/orchestration/execution_orchestrator.py
@@ -329,8 +329,8 @@ class ExecutionOrchestrator:
                         
                         stuck_duration = current_time - self._stuck_aggregation_nodes[node_key]
                         
-                        # If stuck for more than 5 minutes, force transition or log detailed debug info
-                        if stuck_duration > 300:  # 5 minutes
+                        # If stuck, force transition or log detailed debug info
+                        if stuck_duration > self.config.execution.max_stuck_duration:
                             logger.error(f"🚨 INFINITE LOOP DETECTED: Node {node.task_id} stuck in PLAN_DONE for {stuck_duration:.1f}s")
                             # Force check with detailed logging
                             can_agg = self.state_manager.can_aggregate(node)

--- a/src/sentientresearchagent/hierarchical_agent_framework/orchestration/recovery_manager.py
+++ b/src/sentientresearchagent/hierarchical_agent_framework/orchestration/recovery_manager.py
@@ -180,7 +180,7 @@ class TimeoutRecoveryStrategy(RecoveryStrategy):
         stuck_duration = time.time() - start_time
         
         # Decide recovery action based on duration
-        if stuck_duration > 300:  # 5 minutes
+        if stuck_duration > self.config.execution.max_stuck_duration:
             # Too long - fail the node
             node.update_status(
                 TaskStatus.FAILED,


### PR DESCRIPTION
Currently User can stuck in the Infinite Loop and the default value is 300 seconds to get out from it.
This PR allows users to configure it by adding `max_stuck_duration` to your `sentient.yaml` base configuration.